### PR TITLE
Extraction of hapi server logic

### DIFF
--- a/bin/open-github-teams
+++ b/bin/open-github-teams
@@ -1,50 +1,19 @@
 #!/usr/bin/env node
 
-var hapi = require('hapi')
-var secret = process.env.SECRET
-var conn
-
-if (secret && (process.env.HTTP_ONLY || '').toLowerCase() !== 'true') {
-  var createServer = require('auto-sni')
-  conn = {
-    listener: createServer({
-      // we need SSL for the webhook but the access is just-fine™ via http
-      forceSSL: false,
-      email: process.env.HTTPS_EMAIL,
-      agreeTos: process.env.HTTPS_AGREE === 'yes',
-      ports: {
-        http: process.env.HTTP_PORT || 80,
-        https: process.env.HTTPS_PORT || 443
-      }
-    }),
-    autoListen: false,
-    tls: true
-  }
-} else {
-  conn = {
-    port: process.env.HTTP_PORT || 80
-  }
-}
-
-var server = new hapi.Server()
-server.connection(conn)
-server.register([{
-  register: require('good'),
-  options: {
-    opsInterval: 1000,
-    reporters: [{
-      reporter: require('good-console'),
-      events: { log: '*', response: '*' }
-    }]
-  }
-}, {
-  register: require('../lib/hapiPlugin.js'),
-  options: {
+require('../lib/hapiServer')({
+  connection: {
+    httpOnly: process.env.HTTP_ONLY,
+    email: process.env.HTTPS_EMAIL,
+    agreeTos: process.env.HTTPS_AGREE,
+    http: process.env.HTTP_PORT,
+    https: process.env.HTTPS_PORT
+  },
+  openGithubTeams: {
     githubOrganization: process.env.GITHUB_ORG,
     githubApiToken: process.env.GITHUB_TOKEN,
-    webhookSecret: secret
+    webhookSecret: process.env.SECRET
   }
-}], function (err) {
+}, function (err, server) {
   if (err) throw err
   server.start(function (err) {
     if (err) throw err

--- a/bin/open-github-teams
+++ b/bin/open-github-teams
@@ -4,9 +4,9 @@ require('../lib/hapiServer')({
   connection: {
     httpOnly: process.env.HTTP_ONLY,
     email: process.env.HTTPS_EMAIL,
-    agreeTos: process.env.HTTPS_AGREE,
-    http: process.env.HTTP_PORT,
-    https: process.env.HTTPS_PORT
+    agreeTos: process.env.HTTPS_AGREE === 'yes',
+    http: process.env.HTTP_PORT || 80,
+    https: process.env.HTTPS_PORT || 443
   },
   openGithubTeams: {
     githubOrganization: process.env.GITHUB_ORG,

--- a/bin/open-github-teams
+++ b/bin/open-github-teams
@@ -2,7 +2,7 @@
 
 require('../lib/hapiServer')({
   connection: {
-    httpOnly: process.env.HTTP_ONLY,
+    httpOnly: /^\s*true|yes\s*$/ig.test(process.env.HTTP_ONLY),
     email: process.env.HTTPS_EMAIL,
     agreeTos: process.env.HTTPS_AGREE === 'yes',
     http: process.env.HTTP_PORT || 80,

--- a/lib/githubApiForToken.js
+++ b/lib/githubApiForToken.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = function (token) {
   var GitHubApi = require('github')
   var github = new GitHubApi({

--- a/lib/hapiConnection.js
+++ b/lib/hapiConnection.js
@@ -1,0 +1,24 @@
+'use strict'
+
+module.exports = function (options) {
+  if (options.httpOnly) {
+    return {
+      port: options.http || 80
+    }
+  }
+  var createServer = require('auto-sni')
+  return {
+    listener: createServer({
+      // we need SSL for the webhook but the access is just-fine™ via http
+      forceSSL: false,
+      email: options.email,
+      agreeTos: options.agreeTos,
+      ports: {
+        http: options.http,
+        https: options.https
+      }
+    }),
+    autoListen: false,
+    tls: true
+  }
+}

--- a/lib/hapiPlugin.js
+++ b/lib/hapiPlugin.js
@@ -1,4 +1,5 @@
 'use strict'
+
 var Path = require('path')
 
 function registerHapiPlugin (server, options, next) {

--- a/lib/hapiServer.js
+++ b/lib/hapiServer.js
@@ -11,10 +11,10 @@ module.exports = function (options, callback) {
         // we need SSL for the webhook but the access is just-fine™ via http
         forceSSL: false,
         email: options.connection.email,
-        agreeTos: options.connection.agreeTos === 'yes',
+        agreeTos: options.connection.agreeTos,
         ports: {
-          http: options.connection.http || 80,
-          https: options.connection.https || 443
+          http: options.connection.http,
+          https: options.connection.https
         }
       }),
       autoListen: false,

--- a/lib/hapiServer.js
+++ b/lib/hapiServer.js
@@ -1,33 +1,14 @@
+'use strict'
 
 var hapi = require('hapi')
 
 module.exports = function (options, callback) {
-  var conn
-
-  if (options.openGithubTeams.secret && (options.connection.httpOnly || '').toLowerCase() !== 'true') {
-    var createServer = require('auto-sni')
-    conn = {
-      listener: createServer({
-        // we need SSL for the webhook but the access is just-fine™ via http
-        forceSSL: false,
-        email: options.connection.email,
-        agreeTos: options.connection.agreeTos,
-        ports: {
-          http: options.connection.http,
-          https: options.connection.https
-        }
-      }),
-      autoListen: false,
-      tls: true
-    }
-  } else {
-    conn = {
-      port: options.connection.http || 80
-    }
+  if (!options.openGithubTeams.secret) {
+    options.connection.httpOnly = true
   }
 
   var server = new hapi.Server()
-  server.connection(conn)
+  server.connection(require('./hapiConnection.js')(options.connection))
   server.register([{
     register: require('good'),
     options: {

--- a/lib/hapiServer.js
+++ b/lib/hapiServer.js
@@ -1,0 +1,46 @@
+
+var hapi = require('hapi')
+
+module.exports = function (options, callback) {
+  var conn
+
+  if (options.openGithubTeams.secret && (options.connection.httpOnly || '').toLowerCase() !== 'true') {
+    var createServer = require('auto-sni')
+    conn = {
+      listener: createServer({
+        // we need SSL for the webhook but the access is just-fine™ via http
+        forceSSL: false,
+        email: options.connection.email,
+        agreeTos: options.connection.agreeTos === 'yes',
+        ports: {
+          http: options.connection.http || 80,
+          https: options.connection.https || 443
+        }
+      }),
+      autoListen: false,
+      tls: true
+    }
+  } else {
+    conn = {
+      port: options.connection.http || 80
+    }
+  }
+
+  var server = new hapi.Server()
+  server.connection(conn)
+  server.register([{
+    register: require('good'),
+    options: {
+      opsInterval: 1000,
+      reporters: [{
+        reporter: require('good-console'),
+        events: { log: '*', response: '*' }
+      }]
+    }
+  }, {
+    register: require('./hapiPlugin.js'),
+    options: options.openGithubTeams
+  }], function (err) {
+    callback(err, server)
+  })
+}


### PR DESCRIPTION
The Hapi server logic is currently tightly bound to the bin code. This PR extracts the hapi server and connection logic into one files, this way an the project should be easier to extend.
